### PR TITLE
Fix a typo

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1071,7 +1071,7 @@
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<dict>
 				<key>boot-args</key>
-				<string>-no_comat_check</string>
+				<string>-no_compat_check</string>
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>prev-lang:kbd</key>


### PR DESCRIPTION
boot args: -no_compat_check

![1617862673243](https://user-images.githubusercontent.com/743718/113978365-11f49c00-986e-11eb-810f-52ceffbdf34c.jpg)
