### PR TITLE
Fix SMBIOS so that installation works on Big Sur

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1144,7 +1144,7 @@
 			<key>SpoofVendor</key>
 			<true/>
 			<key>SystemProductName</key>
-			<string>MacBookPro10,2</string>
+			<string>MacBookPro11,1</string>
 			<key>SystemSerialNumber</key>
 			<string></string>
 			<key>SystemUUID</key>


### PR DESCRIPTION
`MacBookPro10,2` is for up-to and including macOS 10.15, Catalina. For Big Sur it should be `MacBookPro11,1`.