### PR TITLE
Change layout-id to 28 to fix low volume issue

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -462,7 +462,7 @@
 			<key>PciRoot(0x0)/Pci(0x1b,0x0)</key>
 			<dict>
 				<key>layout-id</key>
-				<data>NwAAAA==</data>
+				<data>HAAAAA==</data>
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>


### PR DESCRIPTION
Fixes Issue #68 where volume is low when booting with headset/speaker connected