### PR TITLE
Add ExFAT support for dual-boot with Windows

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -1200,6 +1200,7 @@
 			<string>HfsPlus.efi</string>
 			<string>OpenCanopy.efi</string>
 			<string>OpenRuntime.efi</string>
+			<string>ExFatDxe.efi</string>
 		</array>
 		<key>Input</key>
 		<dict>


### PR DESCRIPTION
We all know that NTFS doesn't work well with MacOS, nor does APFS with Windows 10. When creating a dual-boot hackintosh system, most would opt to create an ExFAT partition in their internal drive that can be used by both OSes instead. I myself am running MacOS Catalina alongside Windows 10. However, I experienced certain bugs using ExFAT in Catalina:
~~1. Spotlight doesn't work properly (it reindexes every single boot, which degrades performance and heats up the laptop.~~
EDIT: **Spotlight still reindexes the ExFAT partition every reboot.** I guess I'll need to make a full reinstall soon.
2. TextEdit doesn't save/overwrite .txt files.
3. Microsoft Office doesn't save/overwrite files sometimes as well.
4. Some of my files suddenly disappeared (although perhaps MRT.app is to blame here).
And I can confirm that all of these services work well in the main APFS partition. 
Eventually I found a particular driver by acidanthera (though not readily bundled with opencore releases) that gives full ExFAT support. Indeed it fixed all of the bugs I mentioned above.